### PR TITLE
style: fix img size fix for main-category-img-container img element

### DIFF
--- a/server/public/stylesheets/main-category.css
+++ b/server/public/stylesheets/main-category.css
@@ -53,6 +53,9 @@
   overflow: hidden;
   transition: transform 0.3s ease-in-out;
 }
+.main-category-img-container img {
+  width: 100%;
+}
 .main-category-img-overlay {
   position: absolute;
   width: 100%;

--- a/server/public/stylesheets/styles.css
+++ b/server/public/stylesheets/styles.css
@@ -25,7 +25,6 @@ canvas,
 svg {
   display: block;
   max-width: 100%;
-  width: 100%;
 }
 input,
 button,


### PR DESCRIPTION
### Action
- add width: 100% to .main-category-img-container img element

### Context
- to fill ink property images to container size